### PR TITLE
Rename option `id` to `number` for case related commands

### DIFF
--- a/src/commands/case/details.rs
+++ b/src/commands/case/details.rs
@@ -18,14 +18,14 @@ pub async fn run(
 ) -> ResponseData {
     extract!(context.interaction, guild_id);
 
-    let case_id = get_required_option!(
-        context.options.get("id"), CommandOptionValue::Integer
+    let case_index = get_required_option!(
+        context.options.get("number"), CommandOptionValue::Integer
     );
 
     let case = mongodb.cases.find_one(
         doc! {
             "guild_id": guild_id.to_string(),
-            "index": case_id,
+            "index": case_index,
             "removed": false
         }, None
     ).await.map_err(Error::from)?.ok_or("Cannot find case with selected id")?;

--- a/src/commands/case/edit.rs
+++ b/src/commands/case/edit.rs
@@ -21,8 +21,8 @@ pub async fn run(
     extract!(context.interaction, member, guild_id);
     extract!(member, user);
 
-    let case_id = get_required_option!(
-        context.options.get("id"), CommandOptionValue::Integer
+    let case_index = get_required_option!(
+        context.options.get("number"), CommandOptionValue::Integer
     );
 
     let reason = get_required_option!(
@@ -34,7 +34,7 @@ pub async fn run(
     }
 
     let mut case = mongodb.cases.find_one(
-        doc! { "guild_id": guild_id.to_string(), "index": case_id, "removed": false }, None
+        doc! { "guild_id": guild_id.to_string(), "index": case_index, "removed": false }, None
     ).await.map_err(Error::from)?.ok_or("There is no case with selected id")?;
 
     if case.moderator_id != user.id {
@@ -42,7 +42,7 @@ pub async fn run(
     }
 
     mongodb.cases.update_one(
-        doc! { "guild_id": guild_id.to_string(), "index": case_id, "removed": false },
+        doc! { "guild_id": guild_id.to_string(), "index": case_index, "removed": false },
         doc! { "$set": {"reason": reason.to_owned() } }, None
     ).await.map_err(Error::from)?;
 

--- a/src/commands/case/remove.rs
+++ b/src/commands/case/remove.rs
@@ -18,12 +18,14 @@ pub async fn run(
     config: GuildConfig
 ) -> ResponseData {
 
-    let case_id = *get_required_option!(context.options.get("id"), CommandOptionValue::Integer);
+    let case_index = *get_required_option!(
+        context.options.get("number"), CommandOptionValue::Integer
+    );
 
     let removed_case = mongodb.cases.find_one_and_update(
         doc! {
             "guild_id": config.guild_id.to_string(),
-            "index": case_id,
+            "index": case_index,
             "removed": false
         }, doc! { "$set": {"removed": true } }, None
     ).await.map_err(Error::from)?.ok_or("Cannot find case with selected id")?;


### PR DESCRIPTION
Naming things that represent case index in the guild as `id` is wrong because it's per server number. Also, there exists an id automatically given by MongoDB.

This change will affect the following commands:
 -  `/case remove`
 - `/case details`
 - `/case edit`